### PR TITLE
fix: corrigir resposta HTTP para CEPs não encontrados

### DIFF
--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -39,10 +39,10 @@ func (h *Handler) getWeather(w stdhttp.ResponseWriter, r *stdhttp.Request) {
 		fmt.Printf("Erro ao processar CEP %s: %v\n", zip, err)
 
 		switch {
-		case errors.Is(err, service.ErrInvalidZip()):
+		case errors.Is(err, service.ErrInvalidZip):
 			httpJSON(w, stdhttp.StatusUnprocessableEntity, map[string]string{"message": "invalid zipcode"})
 			return
-		case errors.Is(err, service.ErrNotFound()):
+		case errors.Is(err, service.ErrNotFound):
 			httpJSON(w, stdhttp.StatusNotFound, map[string]string{"message": "can not find zipcode"})
 			return
 		default:

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	"encoding/json"
+)
+
 type WeatherResponse struct {
 	TempC float64 `json:"temp_C"`
 	TempF float64 `json:"temp_F"`
@@ -7,11 +11,46 @@ type WeatherResponse struct {
 }
 
 type ViaCEPResult struct {
-	CEP         string `json:"cep"`
+	Cep         string `json:"cep"`
 	Logradouro  string `json:"logradouro"`
 	Complemento string `json:"complemento"`
 	Bairro      string `json:"bairro"`
-	Localidade  string `json:"localidade"` // cidade
+	Localidade  string `json:"localidade"`
 	UF          string `json:"uf"`
-	Erro        bool   `json:"erro"` // quando CEP não encontrado, viaCEP retorna {"erro": true}
+	IBGE        string `json:"ibge"`
+	GIA         string `json:"gia"`
+	DDD         string `json:"ddd"`
+	SIAFI       string `json:"siafi"`
+	Erro        bool   `json:"-"`
+}
+
+func (v *ViaCEPResult) UnmarshalJSON(data []byte) error {
+	type Alias ViaCEPResult
+	aux := struct {
+		*Alias
+		Erro interface{} `json:"erro"`
+	}{
+		Alias: (*Alias)(v),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	switch e := aux.Erro.(type) {
+	case bool:
+		v.Erro = e
+	case string:
+		v.Erro = e == "true"
+	default:
+		v.Erro = false
+	}
+
+	return nil
+}
+
+type WeatherAPIResponse struct {
+	Current struct {
+		TempC float64 `json:"temp_c"`
+	} `json:"current"`
 }

--- a/internal/viacep/viacep.go
+++ b/internal/viacep/viacep.go
@@ -40,6 +40,10 @@ func (c *HTTPClient) Lookup(ctx context.Context, cep string) (*types.ViaCEPResul
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode == 404 || res.StatusCode == 400 {
+		return &types.ViaCEPResult{Erro: true}, nil
+	}
+
 	if res.StatusCode >= 400 {
 		return nil, fmt.Errorf("viacep http error: %d", res.StatusCode)
 	}


### PR DESCRIPTION
- Define erros como variáveis em vez de funções para permitir comparação correta
- Implementa UnmarshalJSON personalizado para lidar com o campo "erro" que pode ser string ou bool
- Melhora tratamento de erros HTTP na integração com ViaCEP
- Adiciona lógica de detecção específica para CEPs não encontrados
- Garante que a aplicação retorna código 404 com mensagem "can not find zipcode" conforme especificado no desafio.

Resolve o problema em que a API estava retornando "internal error" em vez da mensagem apropriada para CEPs não encontrados.